### PR TITLE
Minimum intensity filter

### DIFF
--- a/run_SODA.py
+++ b/run_SODA.py
@@ -26,6 +26,11 @@ MIN_SIZE = [30,  # Channel 0 # Minimum area (pixels) of spots to analyse
 MIN_AXIS_LENGTH = [3,  # Channel 0  # Minimum length of both ellipse axes of spots to analyse
                    3,  # Channel 1
                    3]  # Channel 2
+MIN_INTENSITY = [
+    0,  # Channel 0  # Minimum intensity of spots to analyse
+    0,  # Channel 1
+    0]  # Channel 2
+
 N_RINGS = 16  # Number of rings around spots (int)
 RING_WIDTH = 1  # Width of rings in pixels
 SELF_SODA = False  # Set to True to compute SODA for couples of spots in the same channel as well
@@ -43,6 +48,7 @@ if __name__ == '__main__':
               'scale_threshold': SCALE_THRESHOLD,
               'min_size': MIN_SIZE,
               'min_axis': MIN_AXIS_LENGTH,
+              'min_intensity': MIN_INTENSITY,
               'roi_thresh': ROI_THRESHOLD,
               'channel_mask': CHANNEL_MASK,
               'remove_channel': REMOVE_CHANNEL,

--- a/steps_SODA.py
+++ b/steps_SODA.py
@@ -133,7 +133,7 @@ class SodaImageAnalysis:
             for p in mask_props:
                 if p.minor_axis_length < self.params['min_axis'][i]:
                     mask_lab[mask_lab == p.label] = 0
-                if p.mean_intensity < self.params['min_intensity'][i]:
+                if p.intensity_mean < self.params['min_intensity'][i]:
                     mask_lab[mask_lab == p.label] = 0
             out_mask[i] = mask_lab > 0
         return out_mask

--- a/steps_SODA.py
+++ b/steps_SODA.py
@@ -129,9 +129,11 @@ class SodaImageAnalysis:
         for i, img in enumerate(out_mask):
             img = morphology.remove_small_objects(img, min_size=self.params['min_size'][i])
             mask_lab, num = label(img, connectivity=1, return_num=True)
-            mask_props = regionprops(mask_lab)
+            mask_props = regionprops(mask_lab, intensity_image=self.image[i])
             for p in mask_props:
                 if p.minor_axis_length < self.params['min_axis'][i]:
+                    mask_lab[mask_lab == p.label] = 0
+                if p.mean_intensity < self.params['min_intensity'][i]:
                     mask_lab[mask_lab == p.label] = 0
             out_mask[i] = mask_lab > 0
         return out_mask


### PR DESCRIPTION
Added the option of filtering the detected spots by a minimum intensity. 
The default value should of 0 should not affect the original behaviour of pySODA.